### PR TITLE
nmAPI to except RepyArgumentError's on calling emulfile.check_repy_filename

### DIFF
--- a/nmAPI.py
+++ b/nmAPI.py
@@ -483,7 +483,7 @@ def addfiletovessel(vesselname,filename, filedata):
   
   try:
     check_repy_filename(filename)
-  except TypeError, e:
+  except RepyArgumentError, e:
     raise BadRequest(str(e))
     
   if filename=="":
@@ -527,7 +527,7 @@ def retrievefilefromvessel(vesselname,filename):
 
   try:
     check_repy_filename(filename)
-  except TypeError, e:
+  except RepyArgumentError, e:
     raise BadRequest(str(e))
 
   try:
@@ -557,7 +557,7 @@ def deletefileinvessel(vesselname,filename):
 
   try:
     check_repy_filename(filename)
-  except TypeError, e:
+  except RepyArgumentError, e:
     raise BadRequest(str(e))
 
   if not os.path.exists(vesselname+"/"+filename):


### PR DESCRIPTION
(Note: This is a re-commit of aaaaalbert@312af3fdb40f4e0fc22b9442059dcbd7acb9fc64,
made to use the correct parent commit for easier merging with
SeattleTestbed/nodemanager's master branch).

nmAPI `except`ed TypeError's before, and thus never caught anything,
resulting in the RepyArgumentError reaching callers like the
`nmrequesthandler` (line 111) and missing clauses for the appropriate e
errors. This would cause a nodemanager to report an "Internal Error"
with no further details, as could be observed by uploading through
`seash` a file conflicting with `emulfile`'s filename checks -- in the case of RepyV2, using disallowed
characters, a name starting with "." or "private_", or a too long name.

Thanks go to Rohan Dalvi for reporting the issue!
