### PR TITLE
Use new "subdir" feature in build_component.py

### DIFF
--- a/scripts/config_build.txt
+++ b/scripts/config_build.txt
@@ -1,10 +1,24 @@
+# These are dependencies of the nodemanager itself (which uses the 
+# RepyV2 runtime)
+./*
 DEPENDENCIES/seattlelib_v2/*
 DEPENDENCIES/repy_v2/*
 DEPENDENCIES/portability/*
 DEPENDENCIES/affix/*
 DEPENDENCIES/affix/components/*
-./*
 DEPENDENCIES/common/*
+
+# These are for the `repyV2` sandbox directory, inside of which the 
+# nodemanager will run scripts that have been uploaded to vessels.
+DEPENDENCIES/repy_v2/* repyV2
+./servicelogger.py repyV2
+DEPENDENCIES/portability/* repyV2
+DEPENDENCIES/seattlelib_v2/* repyV2
+DEPENDENCIES/seash/* repyV2
+DEPENDENCIES/affix/* repyV2
+DEPENDENCIES/affix/components/* repyV2
+
+
 # Tests
 test DEPENDENCIES/utf/*
 test tests/*

--- a/scripts/config_initialize.txt
+++ b/scripts/config_initialize.txt
@@ -3,4 +3,5 @@ https://github.com/SeattleTestbed/portability ../DEPENDENCIES/portability
 https://github.com/SeattleTestbed/repy_v2 ../DEPENDENCIES/repy_v2
 https://github.com/SeattleTestbed/affix ../DEPENDENCIES/affix
 https://github.com/SeattleTestbed/common ../DEPENDENCIES/common
+https://github.com/SeattleTestbed/seash ../DEPENDENCIES/seash
 https://github.com/SeattleTestbed/utf ../DEPENDENCIES/utf


### PR DESCRIPTION
This makes explicit many of the things that were done automagically in
`preparetest.py`: Creating subdirectories under the build target path,
selectively copying over files to that subdirectory.